### PR TITLE
Init, again.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+---
+import:
+  - logstash-plugins/.ci:travis/travis.yml@1.x
+matrix:
+  include:
+  - env: ELASTIC_STACK_VERSION=8.2.0 # last release pre-introduction of core CATrustedFingerprintSupport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.0.0
- - Support Mixin for adding API-compatibility with the CATrustedFingerprintSupport introduced in Logstash 8.x.
+ - Support Mixin for adding API-compatibility with the CATrustedFingerprintSupport introduced in Logstash 8.3.
    When a plugin includes this support adapter, and the plugin is run on a version of Logstash that does not
    provide an implementation, the plugin operates as normal but rejects explicit attempts to use
    the `ca_trusted_fingerprint` option. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 1.0.0
+ - Support Mixin for adding API-compatibility with the CATrustedFingerprintSupport introduced in Logstash 8.x.
+   When a plugin includes this support adapter, and the plugin is run on a version of Logstash that does not
+   provide an implementation, the plugin operates as normal but rejects explicit attempts to use
+   the `ca_trusted_fingerprint` option. 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in logstash-mass_effect.gemspec
+gemspec
+
+logstash_path = ENV["LOGSTASH_PATH"] || "../../logstash"
+use_logstash_source = ENV["LOGSTASH_SOURCE"] && ENV["LOGSTASH_SOURCE"].to_s == "1"
+
+if Dir.exist?(logstash_path) && use_logstash_source
+  gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
+  gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Elastic and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# CA Trusted Fingerprint Support Mixin
+
+[![Build Status](https://travis-ci.com/logstash-plugins/logstash-mixin-ca_trusted_fingerprint_support.svg?branch=main)](https://travis-ci.com/logstash-plugins/logstash-mixin-ca_trusted_fingerprint_support)
+
+This gem provides tooling for adding a `ca_trusted_fingerprint` option to Logstash Plugins that maps to an Apache SSL `TrustStrategy` for use by Manticore or Apache HTTP client.
+
+## Usage
+
+1. Add version `~>1.0` of this gem as a runtime dependency of your Logstash plugin's `gemspec`:
+
+    ~~~ ruby
+    Gem::Specification.new do |s|
+      # ...
+
+      s.add_runtime_dependency 'logstash-mixin-ca_trusted_fingerprint_support', '~>1.0'
+    end
+    ~~~
+
+2. In your plugin code, require this library and include it into your plugin class
+   that already inherits `LogStash::Plugin`:
+
+    ~~~ ruby
+    require 'logstash/plugin_mixins/ca_trusted_fingerprint_support'
+
+    class LogStash::Inputs::Foo < Logstash::Inputs::Base
+      # config :ca_trusted_fingerprint, :validate => :sha_256_hex
+      include LogStash::PluginMixins::CATrustedFingerprintSupport
+
+      # ...
+    end
+    ~~~
+
+3. Use the provided `trust_strategy_for_ca_trusted_fingerprint` method to acquire an 
+   appropriate trust strategy for the given `ca_trusted_fingerprint`(s), or `nil` if
+   no `ca_trusted_fingerprint`s were provided. 
+
+    ~~~ ruby
+      def register
+        # ...
+        ssl_options.merge(:trust_strategy, trust_strategy_for_ca_trusted_fingerprint)
+        @client = Manticore::Client.new(ssl: ssl_options)
+      end
+    ~~~
+
+## Development
+
+This gem:
+ - *MUST* remain API-stable at 1.x
+ - *MUST NOT* introduce additional runtime dependencies

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+# encoding: utf-8
+
+require "logstash/devutils/rake"

--- a/lib/logstash/plugin_mixins/ca_trusted_fingerprint_support.rb
+++ b/lib/logstash/plugin_mixins/ca_trusted_fingerprint_support.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+require 'logstash/namespace'
+require 'logstash/plugin'
+
+module LogStash
+  module PluginMixins
+    ##
+    # This `CATrustedFingerprintSupport` can be included in any `LogStash::Plugin`,
+    # and will ensure that the plugin provides a `ca_trusted_fingerprint` option that
+    # accepts a list of string values.
+    #
+    # When Logstash provides its own CATrustedFingerprint support, it will be used
+    # in place of the stub provided by this support adapter.
+    #
+    # When run on a Logstash that does _not_ provide its own CATrustedFingerprint
+    # support, using the `ca_trusted_fingerprint` option is considered a configuration
+    # error and will prevent the plugin from being initialized.
+    module CATrustedFingerprintSupport
+
+      ##
+      # @api internal (use: `LogStash::Plugin::include`)
+      # @param base [Class]: a class that inherits `LogStash::Plugin`, typically one
+      #                      descending from one of the four plugin base classes
+      #                      (e.g., `LogStash::Inputs::Base`)
+      # @return [void]
+      def self.included(base)
+        fail(ArgumentError, "`#{base}` must inherit LogStash::Plugin") unless base < LogStash::Plugin
+
+        base.include(defined?(BuiltInAdapter) ? BuiltInAdapter : LegacyAdapter)
+      end
+
+      module LegacyAdapter
+        def included(base)
+          base.config(:ca_trusted_fingerprint, :validate => :string, :list => true)
+        end
+
+        def config_init(params)
+          if params.include?("ca_trusted_fingerprint")
+            raise LogStash::ConfigurationError, I18n.t(
+              "logstash.runner.configuration.invalid_plugin_register",
+              :plugin => self.class.config_name,
+              :type => self.class.plugin_type,
+              :error => "The `ca_trusted_fingerprint` option requires Logstash 8.3+; please remove the setting or upgrade Logstash."
+            )
+          end
+          super
+        end
+
+        def trust_strategy_for_ca_trusted_fingerprint
+          nil # API compatibility with core
+        end
+      end
+
+      if defined?(::LogStash::Plugins::CATrustedFingerprintSupport)
+        module BuiltInAdapter
+          def self.included(base)
+            base.include(::LogStash::Plugins::CATrustedFingerprintSupport)
+          end
+        end
+      end
+    end
+  end
+end

--- a/logstash-mixin-ca_trusted_fingerprint_support.gemspec
+++ b/logstash-mixin-ca_trusted_fingerprint_support.gemspec
@@ -2,8 +2,8 @@ Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ca_trusted_fingerprint_support'
   s.version       = "1.0.0"
   s.licenses      = %w(Apache-2.0)
-  s.summary       = "Support for bypassing the TrustManager when presented with a certificate chain containing a matching fingerprint. Currently supports Apache HTTP, including Manticore"
-  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use ca_trusted_fingerprint while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, the provided `ca_trusted_fingerprint` option cannot be used."
+  s.summary       = "Support for Logstash plugins wishing to use the `ca_trusted_fingerprint` support introduced in Logstash 8.3. Currently supports Apache HTTP, including Manticore"
+  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use ca_trusted_fingerprint introduced in Logstash 8.3 while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, the provided `ca_trusted_fingerprint` option cannot be used."
   s.authors       = %w(Elastic)
   s.email         = 'info@elastic.co'
   s.homepage      = 'https://github.com/logstash-plugins/logstash-mixin-ca_trusted_fingerprint_support'

--- a/logstash-mixin-ca_trusted_fingerprint_support.gemspec
+++ b/logstash-mixin-ca_trusted_fingerprint_support.gemspec
@@ -1,0 +1,24 @@
+Gem::Specification.new do |s|
+  s.name          = 'logstash-mixin-ca_trusted_fingerprint_support'
+  s.version       = "1.0.0"
+  s.licenses      = %w(Apache-2.0)
+  s.summary       = "Support for bypassing the TrustManager when presented with a certificate chain containing a matching fingerprint. Currently supports Apache HTTP, including Manticore"
+  s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use ca_trusted_fingerprint while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, the provided `ca_trusted_fingerprint` option cannot be used."
+  s.authors       = %w(Elastic)
+  s.email         = 'info@elastic.co'
+  s.homepage      = 'https://github.com/logstash-plugins/logstash-mixin-ca_trusted_fingerprint_support'
+  s.require_paths = %w(lib vendor/jar-dependencies)
+
+  s.files = %w(ext lib spec vendor).flat_map{|dir| Dir.glob("#{dir}/**/*")}+Dir.glob(["*.md","LICENSE"])
+
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+
+  s.platform = RUBY_PLATFORM
+
+  s.add_runtime_dependency 'logstash-core', '>= 7.0.0'
+
+  s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'rspec', '~> 3.9'
+  s.add_development_dependency 'rspec-its', '~>1.3'
+  s.add_development_dependency 'logstash-codec-plain', '>= 3.1.0' # TODO: really?
+end

--- a/spec/logstash/plugin_mixins/ca_trusted_fingerprint_support_spec.rb
+++ b/spec/logstash/plugin_mixins/ca_trusted_fingerprint_support_spec.rb
@@ -33,7 +33,7 @@ describe LogStash::PluginMixins::CATrustedFingerprintSupport do
       LogStash::Outputs::Base
     ].each do |base_class|
       context "that inherits from `#{base_class}`" do
-        native_support_for_plugin_factory = defined?(::LogStash::Plugins::CATrustedFingerprintSupport)
+        native_support_for_plugin_factory = Gem::Version.create(LOGSTASH_VERSION) >= Gem::Version.create("8.3.0")
 
         let(:plugin_base_class) { base_class }
 

--- a/spec/logstash/plugin_mixins/ca_trusted_fingerprint_support_spec.rb
+++ b/spec/logstash/plugin_mixins/ca_trusted_fingerprint_support_spec.rb
@@ -1,0 +1,95 @@
+# encoding: utf-8
+
+require 'rspec/its'
+
+require "logstash-core"
+
+require 'logstash/inputs/base'
+require 'logstash/filters/base'
+require 'logstash/codecs/base'
+require 'logstash/outputs/base'
+
+require 'logstash/codecs/plain' # to init base plugin with default codec
+
+require "logstash/plugin_mixins/ca_trusted_fingerprint_support"
+
+describe LogStash::PluginMixins::CATrustedFingerprintSupport do
+  let(:ca_trusted_fingerprint_support) { described_class }
+
+  context 'included into a class' do
+    context 'that does not inherit from `LogStash::Plugin`' do
+      let(:plugin_class) { Class.new }
+      it 'fails with an ArgumentError' do
+        expect do
+          plugin_class.send(:include, ca_trusted_fingerprint_support)
+        end.to raise_error(ArgumentError, /LogStash::Plugin/)
+      end
+    end
+
+    [
+      LogStash::Inputs::Base,
+      LogStash::Filters::Base,
+      LogStash::Codecs::Base,
+      LogStash::Outputs::Base
+    ].each do |base_class|
+      context "that inherits from `#{base_class}`" do
+        native_support_for_plugin_factory = defined?(::LogStash::Plugins::CATrustedFingerprintSupport)
+
+        let(:plugin_base_class) { base_class }
+
+        subject(:plugin_class) do
+          Class.new(plugin_base_class) do
+            config_name 'test'
+          end
+        end
+
+        context 'the result' do
+          before(:each) do
+            plugin_class.send(:include, ca_trusted_fingerprint_support)
+          end
+
+          context 'class composition' do
+            if native_support_for_plugin_factory
+              its(:ancestors) { is_expected.to_not include(ca_trusted_fingerprint_support::LegacyAdapter) }
+              its(:ancestors) { is_expected.to include(::LogStash::Plugins::CATrustedFingerprintSupport) }
+            else
+              its(:ancestors) { is_expected.to include(ca_trusted_fingerprint_support::LegacyAdapter)}
+            end
+          end
+
+          context '#initialize' do
+
+            let(:config) { Hash.new }
+            let(:ca_sha) { "1bad1dea"*8 }
+
+            context 'instantiating a plugin without `ca_trusted_fingerprint`s' do
+              subject(:instance) { plugin_class.new config }
+              it 'satisfies the interface' do
+                expect(instance).to be_a_kind_of plugin_class
+                expect(instance).to respond_to(:trust_strategy_for_ca_trusted_fingerprint)
+                expect(instance.trust_strategy_for_ca_trusted_fingerprint).to be_nil
+              end
+            end
+
+            unless native_support_for_plugin_factory
+
+              context 'instantiating a plugin with one `ca_trusted_fingerprint`' do
+                let(:config) { super().merge("ca_trusted_fingerprint" => ca_sha) }
+                it 'is a configuration error' do
+                  expect { plugin_class.new config }.to raise_exception(LogStash::ConfigurationError, a_string_including("`ca_trusted_fingerprint` option requires Logstash 8.3"))
+                end
+              end
+
+              context 'instantiating a plugin with an array of `ca_trusted_fingerprint`s' do
+                let(:config) { super().merge("ca_trusted_fingerprint" => [ca_sha, ca_sha.reverse]) }
+                it 'is a configuration error' do
+                  expect { plugin_class.new config }.to raise_exception(LogStash::ConfigurationError, a_string_including("`ca_trusted_fingerprint` option requires Logstash 8.3"))
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces #1 which was approved at a261f71ef5ca2b461793a25afb1aeb27fe9780d9 but Github has disassociated my fork and lost the commit data :weary:

***
> ## Release notes
> * Support Mixin for adding API-compatibility with the CATrustedFingerprintSupport introduced in Logstash 8.x.
>   When a plugin includes this support adapter, and the plugin is run on a version of Logstash that does not
>   provide an implementation, the plugin operates as normal but rejects explicit attempts to use
>   the `ca_trusted_fingerprint` option.
> 
> ## What does this PR do?
> Provides a support adapter for the CATrustedFingerprint support introduced in Logstash [elastic/logstash#14120](https://github.com/elastic/logstash/pull/14120)
> 
> ## Why is it important/What is the impact to the user?
> Enables plugins to rely on this new API without binding to specific releases of Logstash. Actual USE of the API requires running on a compatible Logstash.
> 
> ## Checklist
> * [x]  My code follows the style guidelines of this project
> * [x]  I have commented my code, particularly in hard-to-understand areas
> * [x]  I have made corresponding changes to the documentation
> * [x]  I have made corresponding change to the default configuration files (and/or docker env variables)
> * [x]  I have added tests that prove my fix is effective or that my feature works

