### PR TITLE
add support for Logstash 6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ import:
 matrix:
   include:
   - env: ELASTIC_STACK_VERSION=8.2.0 # last release pre-introduction of core CATrustedFingerprintSupport
+  - env: ELASTIC_STACK_VERSION=6.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1
+  - Include support for plugins running on Logstash 6.8 [#5](https://github.com/logstash-plugins/logstash-mixin-ca_trusted_fingerprint_support/pull/5)
+
 ## 1.0.0
   - Support Mixin for adding API-compatibility with the CATrustedFingerprintSupport introduced in Logstash 8.3 [#2](https://github.com/logstash-plugins/logstash-mixin-ca_trusted_fingerprint_support/pull/2)
     - When a plugin includes this support adapter, and the plugin is run on

--- a/logstash-mixin-ca_trusted_fingerprint_support.gemspec
+++ b/logstash-mixin-ca_trusted_fingerprint_support.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-mixin-ca_trusted_fingerprint_support'
-  s.version       = "1.0.0"
+  s.version       = "1.0.1"
   s.licenses      = %w(Apache-2.0)
   s.summary       = "Support for Logstash plugins wishing to use the `ca_trusted_fingerprint` support introduced in Logstash 8.3. Currently supports Apache HTTP, including Manticore"
   s.description   = "This gem is meant to be a dependency of any Logstash plugin that wishes to use ca_trusted_fingerprint introduced in Logstash 8.3 while maintaining backward-compatibility with earlier Logstash releases. When used on older Logstash versions, the provided `ca_trusted_fingerprint` option cannot be used."
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.platform = RUBY_PLATFORM
 
-  s.add_runtime_dependency 'logstash-core', '>= 7.0.0'
+  s.add_runtime_dependency 'logstash-core', '>= 6.8.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
## Release notes

[rn: skip]

## What does this PR do?


Adds Logstash 6.8 to the matrix and relaxes the dependency declaration on `logstash-core` to `>= 6.8.0`.

## Why is it important/What is the impact to the user?

Allows this plugin to be consumed by `logstash-output-elasticsearch` on all versions of Logstash for which it can be installed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

Relates logstash-plugins/logstash-output-elasticsearch#1074 (build failure on LS 6.8)
